### PR TITLE
Bugfix: Coordinates Swapped during Artwork Parsing

### DIFF
--- a/LasVegasArtWorkTour/ArtworkVC.swift
+++ b/LasVegasArtWorkTour/ArtworkVC.swift
@@ -61,9 +61,9 @@ class ArtworkVC: UIViewController {
             //print("artType: \(artType)")
             let artURL = artRecord["path"].stringValue
             //print("artURL: \(artURL)")
-            let artGeoLocLat = artRecord["location_1"]["coordinates"][0].stringValue
+            let artGeoLocLat = artRecord["location_1"]["coordinates"][1].stringValue
             //print("artGeoLoc: \(artGeoLocLat)")
-            let artGeoLocLon = artRecord["location_1"]["coordinates"][1].stringValue
+            let artGeoLocLon = artRecord["location_1"]["coordinates"][0].stringValue
             //print("artGeoLocLon: \(artGeoLocLon)")
             
             let lat = (artGeoLocLat as NSString).doubleValue

--- a/LasVegasArtWorkTour/DownloadDataVC.swift
+++ b/LasVegasArtWorkTour/DownloadDataVC.swift
@@ -67,9 +67,9 @@ class DownloadDataVC: UIViewController {
             //print("artType: \(artType)")
             let artURL = artRecord["path"].stringValue
             //print("artURL: \(artURL)")
-            let artGeoLocLat = artRecord["location_1"]["coordinates"][0].stringValue
+            let artGeoLocLat = artRecord["location_1"]["coordinates"][1].stringValue
             //print("artGeoLoc: \(artGeoLocLat)")
-            let artGeoLocLon = artRecord["location_1"]["coordinates"][1].stringValue
+            let artGeoLocLon = artRecord["location_1"]["coordinates"][0].stringValue
             //print("artGeoLocLon: \(artGeoLocLon)")
             
             let lat = (artGeoLocLat as NSString).doubleValue


### PR DESCRIPTION
When parsing the Artwork data from the server, longitude and latitude
were swapped.